### PR TITLE
updated delete contact feature

### DIFF
--- a/Flipcart-Clone-API/src/main/java/com/self/flipcart/serviceimpl/ContactServiceImpl.java
+++ b/Flipcart-Clone-API/src/main/java/com/self/flipcart/serviceimpl/ContactServiceImpl.java
@@ -21,6 +21,7 @@ public class ContactServiceImpl implements ContactService {
     private AddressRepo addressRepo;
     private ResponseStructure<Contact> structure;
     private ResponseStructure<List<Contact>> structureList;
+
     @Override
     public ResponseEntity<ResponseStructure<List<Contact>>> addContact(ContactRequest contactRequest, String addressId) {
         return addressRepo.findById(addressId).map(address -> {
@@ -40,7 +41,7 @@ public class ContactServiceImpl implements ContactService {
             return new ResponseEntity<>(structureList.setStatus(HttpStatus.OK.value())
                     .setMessage("Successfully updated contact")
                     .setData(contactRepo.findAllByAddress(contact.getAddress())), HttpStatus.OK);
-        } ).orElseThrow();
+        }).orElseThrow();
     }
 
     @Override
@@ -52,7 +53,7 @@ public class ContactServiceImpl implements ContactService {
 
     @Override
     public ResponseEntity<ResponseStructure<List<Contact>>> getContactsByAddress(String addressId) {
-       return addressRepo.findById(addressId).map(address -> new ResponseEntity<>(structureList.setStatus(HttpStatus.FOUND.value())
+        return addressRepo.findById(addressId).map(address -> new ResponseEntity<>(structureList.setStatus(HttpStatus.FOUND.value())
                 .setMessage("contacts found b address")
                 .setData(contactRepo.findAllByAddress(address)), HttpStatus.FOUND)).orElseThrow();
 
@@ -63,9 +64,11 @@ public class ContactServiceImpl implements ContactService {
         return contactRepo.findById(contactId).map(contact -> {
             contactRepo.delete(contact);
             List<Contact> contacts = contactRepo.findAllByAddress(contact.getAddress());
-            if(!contacts.get(0).isPrimary()){
-                contacts.get(0).setPrimary(true);
-                contactRepo.save(contacts.get(0));
+            if (contacts.size() > 0) {
+                if (!contacts.get(0).isPrimary()) {
+                    contacts.get(0).setPrimary(true);
+                    contactRepo.save(contacts.get(0));
+                }
             }
             return ResponseEntity.ok(structureList.setStatus(HttpStatus.OK.value())
                     .setMessage("Successfully deleted the contact")

--- a/Flipcart-Clone-UI/src/Components/Private/Common/ContactForm.jsx
+++ b/Flipcart-Clone-UI/src/Components/Private/Common/ContactForm.jsx
@@ -216,8 +216,10 @@ const ContactForm = () => {
       setContactId1("");
       setContactName1("");
       setContactNumber1("");
-      setContactPrimary1(false);
-      if(contactId2 !== "") setContactPrimary2(true);
+      if(contactId2 !== ""){
+        setContactPrimary1(false);
+        setContactPrimary2(true);
+      } 
     }
     if(contactId2 === id){
       setContactId2("");

--- a/Flipcart-Clone-UI/src/Components/Private/Common/ContactForm.jsx
+++ b/Flipcart-Clone-UI/src/Components/Private/Common/ContactForm.jsx
@@ -217,7 +217,7 @@ const ContactForm = () => {
       setContactName1("");
       setContactNumber1("");
       setContactPrimary1(false);
-      setContactPrimary2(true);
+      if(contactId2 !== "") setContactPrimary2(true);
     }
     if(contactId2 === id){
       setContactId2("");


### PR DESCRIPTION
- Fixed backed to validate if there is any contact in the list before operating on the list, eliminating the risk  `ArrayOutOfBoundException` during the delete operation. The issue occurred while deleting the last contact from the list.

- Fixed UI to not update the Secont contact to primary if the the Id is blank, makes sure that first contact has to first preference to be primary.